### PR TITLE
Add SPARQL Endpoint as source

### DIFF
--- a/sources/sparql_endpoint.json
+++ b/sources/sparql_endpoint.json
@@ -1,0 +1,8 @@
+{
+  "id": "SPARQL_ENDPOINT",
+  "name": "SPARQL Endpoint",
+  "categories": ["DATABASE", "CUSTOM", "PUBLIC_DATA"],
+  "iconUrl": "https://www.w3.org/RDF/icons/rdf_w3c_icon.48.gif",
+  "sourceUrl": "https://www.w3.org/TR/sparql11-protocol/",
+  "dataVisibility": ["PUBLIC", "PRIVATE"]
+}

--- a/sources/sparql_endpoint.json
+++ b/sources/sparql_endpoint.json
@@ -1,7 +1,7 @@
 {
-  "id": "SPARQL_ENDPOINT",
-  "name": "SPARQL Endpoint",
-  "categories": ["DATABASE", "CUSTOM", "PUBLIC_DATA"],
+  "id": "CUSTOM_SPARQL",
+  "name": "Custom SPARQL",
+  "categories": ["DATABASE", "CUSTOM"],
   "iconUrl": "https://www.w3.org/RDF/icons/rdf_w3c_icon.48.gif",
   "sourceUrl": "https://www.w3.org/TR/sparql11-protocol/",
   "dataVisibility": ["PUBLIC", "PRIVATE"]


### PR DESCRIPTION
SPARQL Endpoint is an HTTP API endpoint following [the SPARQL Protocol specification](https://www.w3.org/TR/sparql11-protocol/) developed and standardized by [W3C](https://www.w3.org/).

Example SPARQL Endpoints: [Wikidata](https://query.wikidata.org/sparql) and [DBpedia](http://dbpedia.org/sparql).

An example connector: https://github.com/datadotworld/data-studio-connector