### PR TITLE
Add ContentKing for ContentKing GDS connector

### DIFF
--- a/organizations/contentking.json
+++ b/organizations/contentking.json
@@ -1,0 +1,6 @@
+{
+  "id": "CONTENTKING",
+  "name": "ContentKing",
+  "iconUrl": "https://assets.contentkingapp.com/public_assets/images/kevin-40x40.png",
+  "orgUrl": "https://www.contentkingapp.com/"
+}

--- a/sources/contentking.json
+++ b/sources/contentking.json
@@ -1,0 +1,9 @@
+{
+  "id": "CONTENTKING",
+  "name": "ContentKing",
+  "categories": ["SEO"],
+  "organization": "CONTENTKING",
+  "iconUrl": "https://assets.contentkingapp.com/public_assets/images/kevin-40x40.png",
+  "sourceUrl": "https://www.contentkingapp.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
We closed https://github.com/googledatastudio/ds-data-registry/pull/214 and opened this one, as I'm the one who signed the CLA (CLA completed on Jul 3, 2019).