### PR TITLE
Fix iconUrl of "Simplifi" source

### DIFF
--- a/sources/simplifi.json
+++ b/sources/simplifi.json
@@ -3,7 +3,7 @@
   "name": "Simplifi",
   "categories": ["ADVERTISING"],
   "organization": "SIMPLIFI",
-  "iconUrl": "https://static.funnel.io/logos/icon48x48/simplifi.png",
+  "iconUrl": "https://app.simpli.fi/assets/logo.png",
   "sourceUrl": "https://www.simpli.fi/",
   "dataVisibility": ["PRIVATE"]
 }


### PR DESCRIPTION
The iconUrl of the "Simplifi" source should be something on a Simplifi domain, not on the domain of Funnel (an agency that has created a connector to pull data from this source).