### PR TITLE
Add RapidPro source, Nyaruka organization

### DIFF
--- a/organizations/nyaruka.json
+++ b/organizations/nyaruka.json
@@ -1,0 +1,6 @@
+{
+  "id": "Nyaruka",
+  "name": "Nyaruka",
+  "iconUrl": "https://nyaruka.com/sitestatic/images/favicon.png",
+  "orgUrl": "https://www.nyaruka.com/"
+}

--- a/organizations/nyaruka.json
+++ b/organizations/nyaruka.json
@@ -1,5 +1,5 @@
 {
-  "id": "Nyaruka",
+  "id": "NYARUKA",
   "name": "Nyaruka",
   "iconUrl": "https://nyaruka.com/sitestatic/images/favicon.png",
   "orgUrl": "https://nyaruka.com/"

--- a/organizations/nyaruka.json
+++ b/organizations/nyaruka.json
@@ -2,5 +2,5 @@
   "id": "Nyaruka",
   "name": "Nyaruka",
   "iconUrl": "https://nyaruka.com/sitestatic/images/favicon.png",
-  "orgUrl": "https://www.nyaruka.com/"
+  "orgUrl": "https://nyaruka.com/"
 }

--- a/sources/rapidpro.json
+++ b/sources/rapidpro.json
@@ -1,0 +1,9 @@
+{
+  "id": "RAPIDPRO",
+  "name": "RapidPro",
+  "categories": ["DATA_COLLECTION"],
+  "organization": "NYARUKA",
+  "iconUrl": "http://app.rapidpro.io/sitestatic//brands/rapidpro/rapidpro.ico",
+  "sourceUrl": "https://community.rapidpro.io/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
In preparation of submitting new community data studio connector:
  https://github.com/nyaruka/community-connectors/

RapidPro is an Open Source data collection tool used around the world to automate messaging applications. UNICEF uses it in 80+ countries at national scale and thousands of other organizations use it around the world to create automated bot platforms across SMS, Facebook Messenger, WhatsApp and more..