### PR TITLE
Added support for Kobler

### DIFF
--- a/sources/kobler.json
+++ b/sources/kobler.json
@@ -1,0 +1,10 @@
+{
+    "id": "KOBLER",
+    "name": "Kobler Analytics",
+    "categories": ["ANALYTICS"],
+    "organization": "KOBLER",
+    "iconUrl":
+      "https://kobler.no/favicon.ico",
+    "sourceUrl": "https://kobler.no",
+    "dataVisibility": ["PRIVATE"]
+  }


### PR DESCRIPTION
Added support for Kobler, which is a topical marketing service. This is needed in order to get out the community connector for Kobler Analytics reporting.