### PR TITLE
Add Mapify organization and Mapify Dataset source

### DIFF
--- a/organizations/mapify.json
+++ b/organizations/mapify.json
@@ -1,0 +1,6 @@
+{
+    "id": "MAPIFY",
+    "name": "Mapify",
+    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapifylogo_simple_32x32.png",
+    "orgUrl": "https://www.mapify.ai"
+  }

--- a/organizations/mapify.json
+++ b/organizations/mapify.json
@@ -1,6 +1,7 @@
 {
-    "id": "MAPIFY",
-    "name": "Mapify",
-    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapify-looker-studio-connector.png",
-    "orgUrl": "https://www.mapify.ai"
-  }
+  "id": "MAPIFY",
+  "name": "Mapify",
+  "iconUrl":
+    "https://storage.googleapis.com/mapify-demos/mapify/mapify-looker-studio-connector.png",
+  "orgUrl": "https://www.mapify.ai"
+}

--- a/organizations/mapify.json
+++ b/organizations/mapify.json
@@ -1,6 +1,6 @@
 {
     "id": "MAPIFY",
     "name": "Mapify",
-    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapifylogo_simple_32x32.png",
+    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapify-looker-studio-connector.png",
     "orgUrl": "https://www.mapify.ai"
   }

--- a/sources/mapify_dataset.json
+++ b/sources/mapify_dataset.json
@@ -1,0 +1,9 @@
+{
+    "id": "MAPIFY_DATASET",
+    "name": "Mapify Dataset",
+    "categories": ["IOT"],
+    "organization": "MAPIFY",
+    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapifylogo_simple_32x32.png",
+    "sourceUrl": "https://www.mapify.ai",
+    "dataVisibility": ["PRIVATE"]
+  }

--- a/sources/mapify_dataset.json
+++ b/sources/mapify_dataset.json
@@ -1,9 +1,10 @@
 {
-    "id": "MAPIFY_DATASET",
-    "name": "Mapify Dataset",
-    "categories": ["IOT"],
-    "organization": "MAPIFY",
-    "iconUrl": "https://storage.googleapis.com/mapify-demos/mapify/mapifylogo_simple_32x32.png",
-    "sourceUrl": "https://www.mapify.ai",
-    "dataVisibility": ["PRIVATE"]
-  }
+  "id": "MAPIFY_DATASET",
+  "name": "Mapify Dataset",
+  "categories": ["IOT"],
+  "organization": "MAPIFY",
+  "iconUrl":
+    "https://storage.googleapis.com/mapify-demos/mapify/mapifylogo_simple_32x32.png",
+  "sourceUrl": "https://www.mapify.ai",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Created organization (https://mapify.ai) and source for Mapify datasets (https://docs.mapify.ai/mapify-console/datasets/)