### PR TITLE
Add city as a platform organization and data sources

### DIFF
--- a/organizations/caap.json
+++ b/organizations/caap.json
@@ -1,0 +1,6 @@
+{
+    "id": "CAAP",
+    "name": "City as a Platform",
+    "iconUrl": "https://storage.googleapis.com/caap-temp/caap-logo-32px.png",
+    "orgUrl": "https://www.city-platform.com"
+  }

--- a/sources/caap-incident.json
+++ b/sources/caap-incident.json
@@ -1,0 +1,9 @@
+{
+    "id": "CAAP_INCIDENT",
+    "name": "City as a Platform Incidents",
+    "categories": ["API"],
+    "organization": "CAAP",
+    "iconUrl": "https://storage.googleapis.com/caap-temp/caap-logo-32px.png",
+    "sourceUrl": "https://www.city-platform.com",
+    "dataVisibility": ["PRIVATE"]
+  }

--- a/sources/caap-layer.json
+++ b/sources/caap-layer.json
@@ -1,0 +1,9 @@
+{
+    "id": "CAAP_LAYER",
+    "name": "City as a Platform Layer",
+    "categories": ["API"],
+    "organization": "CAAP",
+    "iconUrl": "https://storage.googleapis.com/caap-temp/caap-logo-32px.png",
+    "sourceUrl": "https://www.city-platform.com",
+    "dataVisibility": ["PRIVATE"]
+  }


### PR DESCRIPTION
Add organization and two data sources (Layer and Incidents) for [City as a Platform](https://www.city-platform.com/)