### PR TITLE
Add source: Mercado Libre by Engdata

### DIFF
--- a/organizations/engdata.json
+++ b/organizations/engdata.json
@@ -1,0 +1,6 @@
+{
+  "id": "ENGDATA",
+  "name": "Engdata",
+  "iconUrl": "https://api.engdatarg.com/static/logo_small.png",
+  "orgUrl": "https://api.engdatarg.com"
+}

--- a/sources/mercado_libre.json
+++ b/sources/mercado_libre.json
@@ -1,0 +1,9 @@
+{
+  "id": "MERCADO_LIBRE",
+  "name": "Mercado Libre",
+  "categories": ["ECOMMERCE"],
+  "organization": "ENGDATA",
+  "iconUrl": "https://api.engdatarg.com/static/logo_small.png",
+  "sourceUrl": "https://www.mercadolibre.com",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
This PR adds the Mercado Libre data source under the ECOMMERCE category, with data provided through the Engdata connector platform.

- Organization: Engdata (https://api.engdatarg.com)
- Source: Mercado Libre (https://www.mercadolibre.com)
- Data visibility: PRIVATE (requires user authentication)
