### PR TITLE
Add Followords organization & source

### DIFF
--- a/organizations/followords.json
+++ b/organizations/followords.json
@@ -1,0 +1,7 @@
+{
+  "id": "FOLLOWORDS",
+  "name": "Followords",
+  "iconUrl":
+    "https://followords-ressources.s3.eu-west-3.amazonaws.com/favicon.png",
+  "orgUrl": "https://followords.com/"
+}

--- a/sources/followords.json
+++ b/sources/followords.json
@@ -1,0 +1,10 @@
+{
+  "id": "FOLLOWORDS",
+  "name": "Followords",
+  "categories": ["MARKETING", "SEO", "TOOLS"],
+  "organization": "FOLLOWORDS",
+  "iconUrl":
+    "https://followords-ressources.s3.eu-west-3.amazonaws.com/favicon.png",
+  "sourceUrl": "https://followords.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
This PR adds the Followords source - under the MARKETING, SEO & TOOLS categories - & the Followords organization.

Organization: Followords (https://followords.com/)
Source: Followords (https://followords.com/)
Data visibility: PRIVATE (requires user authentication)