### PR TITLE
Add Squarespace as a source

### DIFF
--- a/sources/squarespace.json
+++ b/sources/squarespace.json
@@ -1,0 +1,11 @@
+{
+    "id": "SQUARESPACE",
+    "name": "Squarespace",
+    "categories": ["ECOMMERCE, MARKETING"],
+    "organization": "SQUARESPACE",
+    "iconUrl": "https://storage.googleapis.com/central-prod-sm-custom-connector-external/12162_1744185960.png",
+    "sourceUrl": "https://www.squarespace.com/",
+    "dataVisibility": [
+        "PRIVATE"
+    ]
+}


### PR DESCRIPTION
Add Squarespace as a source to the registry. Squarespace already existed as organization in the registry, but source was missing. 