### PR TITLE
Add SeoSamba organization and SeoSamba CRM data source

### DIFF
--- a/organizations/seosamba.json
+++ b/organizations/seosamba.json
@@ -1,0 +1,7 @@
+{
+  "id": "seosamba",
+  "name": "SeoSamba",
+  "iconUrl":
+    "https://www.seosamba.com/media/looker_studio_connctor_app/product/crm-green-logo-1-.png",
+  "orgUrl": "https://www.seosamba.com/"
+}

--- a/sources/seosamba_crm.json
+++ b/sources/seosamba_crm.json
@@ -1,6 +1,6 @@
 {
   "id": "seosamba_crm",
-  "name": "SeoSamba CRM",
+  "name":  "SeoSamba CRM",
   "categories": ["CRM"],
   "organization": "seosamba",
   "iconUrl":

--- a/sources/seosamba_crm.json
+++ b/sources/seosamba_crm.json
@@ -1,0 +1,10 @@
+{
+  "id": "seosamba_crm",
+  "name": "SeoSamba CRM",
+  "categories": ["CRM"],
+  "organization": "seosamba",
+  "iconUrl":
+    "https://www.seosamba.com/media/looker_studio_connctor_app/product/crm-green-logo-1-.png",
+  "sourceUrl": "https://www.seosamba.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
This PR adds a new organization "SeoSamba" and a new data source "SeoSamba CRM" to the Data Registry.

SeoSamba CRM is a self-hosted CRM system used to manage leads, organizations, and sales data. The connector allows Looker Studio users to connect to their own SeoSamba CRM instances.

Icons and URLs are included as per guidelines.

Thank you for reviewing!