### PR TITLE
add new sources for windsor.ai

### DIFF
--- a/organizations/boxcast.json
+++ b/organizations/boxcast.json
@@ -1,0 +1,6 @@
+{
+  "id": "BOXCAST",
+  "name": "BoxCast",
+  "iconUrl": "https://www.boxcast.com/favicon.ico",
+  "orgUrl": "https://www.boxcast.com/"
+}

--- a/organizations/chargify.json
+++ b/organizations/chargify.json
@@ -1,0 +1,6 @@
+{
+  "id": "CHARGIFY",
+  "name": "Chargify",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/11/chargify.png",
+  "orgUrl": "https://www.chargify.com/"
+}

--- a/organizations/commercetools.json
+++ b/organizations/commercetools.json
@@ -1,0 +1,6 @@
+{
+  "id": "COMMERCETOOLS",
+  "name": "commercetools",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/05/1_qZWZuv46kiiO5Drkt263JQ.png",
+  "orgUrl": "https://commercetools.com/"
+}

--- a/organizations/posthog.json
+++ b/organizations/posthog.json
@@ -1,0 +1,6 @@
+{
+  "id": "POSTHOG",
+  "name": "PostHog",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2024/02/posthog.png",
+  "orgUrl": "https://posthog.com/"
+}

--- a/organizations/rocket_chat.json
+++ b/organizations/rocket_chat.json
@@ -1,0 +1,6 @@
+{
+  "id": "ROCKET_CHAT",
+  "name": "Rocket.Chat",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/11/rocket_chat.png",
+  "orgUrl": "https://rocket.chat/"
+}

--- a/organizations/smaily.json
+++ b/organizations/smaily.json
@@ -1,0 +1,6 @@
+{
+  "id": "SMAILY",
+  "name": "Smaily",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/04/smaily.png",
+  "orgUrl": "https://smaily.com/"
+}

--- a/organizations/yougov.json
+++ b/organizations/yougov.json
@@ -1,0 +1,6 @@
+{
+  "id": "YOUGOV",
+  "name": "YouGov",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/01/yougov_brandindex.png",
+  "orgUrl": "https://business.yougov.com/"
+}

--- a/sources/boxcast.json
+++ b/sources/boxcast.json
@@ -1,0 +1,9 @@
+{
+  "id": "BOXCAST",
+  "name": "BoxCast",
+  "categories": ["VIDEO"],
+  "organization": "BOXCAST",
+  "iconUrl": "https://www.boxcast.com/favicon.ico",
+  "sourceUrl": "https://www.boxcast.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/chargify.json
+++ b/sources/chargify.json
@@ -1,0 +1,9 @@
+{
+  "id": "CHARGIFY",
+  "name": "Chargify",
+  "categories": ["PAYMENTS"],
+  "organization": "CHARGIFY",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/11/chargify.png",
+  "sourceUrl": "https://www.chargify.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/commercetools.json
+++ b/sources/commercetools.json
@@ -1,0 +1,9 @@
+{
+  "id": "COMMERCETOOLS",
+  "name": "commercetools",
+  "categories": ["ECOMMERCE"],
+  "organization": "COMMERCETOOLS",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/05/1_qZWZuv46kiiO5Drkt263JQ.png",
+  "sourceUrl": "https://commercetools.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/posthog.json
+++ b/sources/posthog.json
@@ -1,0 +1,9 @@
+{
+  "id": "POSTHOG",
+  "name": "PostHog",
+  "categories": ["ANALYTICS"],
+  "organization": "POSTHOG",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2024/02/posthog.png",
+  "sourceUrl": "https://posthog.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/rocket_chat.json
+++ b/sources/rocket_chat.json
@@ -1,0 +1,9 @@
+{
+  "id": "ROCKET_CHAT",
+  "name": "Rocket.Chat",
+  "categories": ["CHAT_TRACKING"],
+  "organization": "ROCKET_CHAT",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/11/rocket_chat.png",
+  "sourceUrl": "https://rocket.chat/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/smaily.json
+++ b/sources/smaily.json
@@ -1,0 +1,9 @@
+{
+  "id": "SMAILY",
+  "name": "Smaily",
+  "categories": ["EMAIL"],
+  "organization": "SMAILY",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/04/smaily.png",
+  "sourceUrl": "https://smaily.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/visma_economic.json
+++ b/sources/visma_economic.json
@@ -1,0 +1,9 @@
+{
+  "id": "VISMA_ECONOMIC",
+  "name": "Visma e-conomic",
+  "categories": ["FINANCE"],
+  "organization": "VISMA",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2025/12/visma_economic.png.webp",
+  "sourceUrl": "https://www.e-conomic.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/yougov_brandindex.json
+++ b/sources/yougov_brandindex.json
@@ -1,0 +1,9 @@
+{
+  "id": "YOUGOV_BRANDINDEX",
+  "name": "YouGov BrandIndex",
+  "categories": ["RESEARCH"],
+  "organization": "YOUGOV",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/01/yougov_brandindex.png",
+  "sourceUrl": "https://business.yougov.com/product/brandindex",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
  Add new data sources and organizations for windsor.ai integration.

  New Organizations (7):
  - BoxCast - Live video streaming platform
  - Chargify - Subscription billing and revenue management
  - commercetools - Headless commerce platform
  - PostHog - Product analytics platform
  - Rocket.Chat - Open source team communication
  - Smaily - Email marketing automation
  - YouGov - Market research and data analytics

  New Sources (8):
  - boxcast - BoxCast (VIDEO)
  - chargify - Chargify (PAYMENTS)
  - commercetools - commercetools (ECOMMERCE)
  - posthog - PostHog (ANALYTICS)
  - rocket_chat - Rocket.Chat (CHAT_TRACKING)
  - smaily - Smaily (EMAIL)
  - visma_economic - Visma e-conomic (FINANCE) - uses existing VISMA organization
  - yougov_brandindex - YouGov BrandIndex (RESEARCH)