### PR TITLE
Add LocalRank source metadata

### DIFF
--- a/organizations/localrank.json
+++ b/organizations/localrank.json
@@ -1,0 +1,6 @@
+{
+  "id": "LOCALRANK",
+  "name": "LocalRank",
+  "iconUrl": "https://app.localrank.so/apple-touch-icon.png",
+  "orgUrl": "https://localrank.so/"
+}

--- a/sources/localrank.json
+++ b/sources/localrank.json
@@ -1,0 +1,9 @@
+{
+  "id": "LOCALRANK",
+  "name": "LocalRank",
+  "categories": ["SEO", "ANALYTICS"],
+  "organization": "LOCALRANK",
+  "iconUrl": "https://app.localrank.so/apple-touch-icon.png",
+  "sourceUrl": "https://localrank.so/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary
- add LocalRank as an organization in the data registry
- add LocalRank as a private SEO/analytics source for Community Connector manifests

## Why
LocalRank's Looker Studio connector now references `LOCALRANK` in the manifest `sources` field, so the registry needs a matching source definition and organization entry.