### PR TITLE
Add Haloscan as a data source

### DIFF
--- a/sources/haloscan.json
+++ b/sources/haloscan.json
@@ -1,0 +1,9 @@
+{
+  "id": "HALOSCAN",
+  "name": "Haloscan",
+  "categories": ["TOOLS", "SEO", "ANALYTICS"],
+  "organization": "Haloscan",
+  "iconUrl": "https://haloscan.com/logos/haloscan.png",
+  "sourceUrl": "https://haloscan.com",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Adding Haloscan (https://haloscan.com) as a new data source.

Haloscan is an SEO platform providing keyword research, SERP analysis, site rankings, and competitor tracking data.

Categories: TOOLS, SEO, ANALYTICS
Data visibility: PRIVATE