### PR TITLE
Add Trakkr source and organization

### DIFF
--- a/organizations/trakkr.json
+++ b/organizations/trakkr.json
@@ -1,0 +1,6 @@
+{
+  "id": "TRAKKR",
+  "name": "Trakkr",
+  "iconUrl": "https://trakkr.ai/logo-mint.png",
+  "orgUrl": "https://trakkr.ai"
+}

--- a/sources/trakkr.json
+++ b/sources/trakkr.json
@@ -1,0 +1,9 @@
+{
+  "id": "TRAKKR",
+  "name": "Trakkr",
+  "categories": ["MARKETING", "ANALYTICS", "Artificial Intelligence"],
+  "organization": "TRAKKR",
+  "iconUrl": "https://trakkr.ai/logo-mint.png",
+  "sourceUrl": "https://trakkr.ai",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary

Adds Trakkr as a data source and organization to the registry.

**Trakkr** is an AI visibility platform that tracks how brands appear in AI search engines (ChatGPT, Claude, Gemini, Perplexity, Copilot, Grok, Meta AI, and DeepSeek).

The Looker Studio community connector provides 17 datasets:
- Visibility over time, by AI model, and by prompt
- Citations list, analytics, and by AI model
- Competitive rankings and heatmap
- Perception metrics, model performance, and prompts
- AI crawler visits over time, by bot, and top pages
- Live AI-referred visitors over time, by source, and top landing pages

### Files added
- `sources/trakkr.json` - Source definition
- `organizations/trakkr.json` - Organization definition

### Links
- Website: https://trakkr.ai
- Connector page: https://trakkr.ai/looker-studio
- Privacy policy: https://trakkr.ai/privacy
- Terms of service: https://trakkr.ai/terms
