### PR TITLE
Add Dataslayer org and source

### DIFF
--- a/organizations/dataslayer.json
+++ b/organizations/dataslayer.json
@@ -1,0 +1,7 @@
+{
+  "id": "DATASLAYER",
+  "name": "Dataslayer",
+  "orgUrl": "https://dataslayer.ai/",
+  "iconUrl":
+  "https://dataslayer-logos-eur.s3.eu-west-1.amazonaws.com/add-on/logo_dataslayer-40x40.jpeg"
+}

--- a/sources/dataslayer_database.json
+++ b/sources/dataslayer_database.json
@@ -1,0 +1,9 @@
+{
+  "id": "DS_DATABASE",
+  "name": "Database",
+  "categories": ["DATABASE"],
+  "organization": "DATASLAYER",
+  "iconUrl": "https://dataslayer-logos-eur.s3.eu-west-1.amazonaws.com/add-on/logo_dataslayer-40x40.jpeg",
+  "sourceUrl": "https://www.dataslayer.ai/connectors/database",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/dataslayer_warehouse.json
+++ b/sources/dataslayer_warehouse.json
@@ -1,0 +1,9 @@
+{
+  "id": "DS_DATA_WAREHOUSE",
+  "name": "Data Warehouse",
+  "categories": ["DATABASE"],
+  "organization": "DATASLAYER",
+  "iconUrl": "https://dataslayer-logos-eur.s3.eu-west-1.amazonaws.com/add-on/logo_dataslayer-40x40.jpeg",
+  "sourceUrl": "https://www.dataslayer.ai/connectors/data-warehouse",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Adding [Dataslayer](https://www.dataslayer.ai/) as organization and a couple of sources:
- Database: This is a generic connector that depends of what the user has shared, so it does not fit in MySQL, Oracle or other database sources already available
- Data Warehouse: This is similar to Database, but Dataslayer stores and manages the data. Same again, no available source match it. If you check, you will see that its "sourceUrl" link does not work. That's because the connector hasn't been published yet. We intent to release it along its LS connector.

Thanks