### PR TITLE
Add Reaudit source and organization

### DIFF
--- a/organizations/reaudit.json
+++ b/organizations/reaudit.json
@@ -1,0 +1,6 @@
+{
+  "id": "REAUDIT",
+  "name": "Reaudit",
+  "iconUrl": "https://reaudit.io/reaudit-ai-logo.svg",
+  "orgUrl": "https://reaudit.io"
+}

--- a/sources/reaudit.json
+++ b/sources/reaudit.json
@@ -1,0 +1,9 @@
+{
+  "id": "REAUDIT",
+  "name": "Reaudit",
+  "categories": ["SEO", "MARKETING", "ANALYTICS"],
+  "organization": "REAUDIT",
+  "iconUrl": "https://reaudit.io/reaudit-ai-logo.svg",
+  "sourceUrl": "https://reaudit.io",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Adds the `REAUDIT` source and `REAUDIT` organization so the Reaudit AI Visibility Looker Studio Community Connector can declare it in its `appsscript.json` manifest.

- `sources/reaudit.json` — source definition (id: `REAUDIT`, categories: SEO / MARKETING / ANALYTICS)
- `organizations/reaudit.json` — organization entry for Reaudit (https://reaudit.io)

This unblocks a Partner Gallery review that flagged the `sources` field as missing from the registry.

Made with [Cursor](https://cursor.com)