### PR TITLE
Add Attentive and ClickMagick as data sources

### DIFF
--- a/organizations/attentive.json
+++ b/organizations/attentive.json
@@ -1,0 +1,6 @@
+{
+  "id": "ATTENTIVE",
+  "name": "Attentive",
+  "orgUrl": "https://www.attentive.com/",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/04/attentive.png"
+}

--- a/organizations/clickmagick.json
+++ b/organizations/clickmagick.json
@@ -1,0 +1,6 @@
+{
+  "id": "CLICKMAGICK",
+  "name": "ClickMagick",
+  "orgUrl": "https://www.clickmagick.com/",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/04/clickmagick.png"
+}

--- a/sources/attentive.json
+++ b/sources/attentive.json
@@ -1,0 +1,9 @@
+{
+  "id": "ATTENTIVE",
+  "name": "Attentive",
+  "categories": ["MARKETING"],
+  "organization": "ATTENTIVE",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/04/attentive.png",
+  "sourceUrl": "https://www.attentive.com/",
+  "dataVisibility": ["PRIVATE"]
+}

--- a/sources/clickmagick.json
+++ b/sources/clickmagick.json
@@ -1,0 +1,9 @@
+{
+  "id": "CLICKMAGICK",
+  "name": "ClickMagick",
+  "categories": ["MARKETING", "ANALYTICS", "ADVERTISING"],
+  "organization": "CLICKMAGICK",
+  "iconUrl": "https://windsor.ai/wp-content/uploads/2026/04/clickmagick.png",
+  "sourceUrl": "https://www.clickmagick.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary
- Adds **Attentive** (SMS marketing) as a new source + organization
- Adds **ClickMagick** (link tracking / attribution) as a new source + organization

## Test plan
- [x] Source IDs match filenames (`attentive`, `clickmagick`)
- [x] Each source references a valid organization defined in this PR
- [x] Categories used (`MARKETING`, `ANALYTICS`, `ADVERTISING`) all exist in `categories.json`
- [x] `dataVisibility` set to `PRIVATE` (per-account data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)