### PR TITLE
Add Whitespark organization and Local Rank Tracker source

### DIFF
--- a/organizations/whitespark.json
+++ b/organizations/whitespark.json
@@ -1,0 +1,6 @@
+{
+  "id": "WHITESPARK",
+  "name": "Whitespark",
+  "iconUrl": "https://static.whitespark.ca/spark.svg",
+  "orgUrl": "https://whitespark.ca"
+}

--- a/sources/whitespark_local_rank_tracker.json
+++ b/sources/whitespark_local_rank_tracker.json
@@ -1,0 +1,9 @@
+{
+  "id": "WHITESPARK_LOCAL_RANK_TRACKER",
+  "name": "Whitespark Local Rank Tracker",
+  "categories": ["SEO", "ANALYTICS"],
+  "organization": "WHITESPARK",
+  "iconUrl": "https://static.whitespark.ca/icons/lrt.png",
+  "sourceUrl": "https://whitespark.ca/local-rank-tracker/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary

  - Adds `organizations/whitespark.json` for Whitespark (https://whitespark.ca), a local SEO software company
  - Adds `sources/whitespark_local_rank_tracker.json` for the Whitespark Local Rank Tracker, a local SEO rank tracking tool
  - Source is categorized under `SEO` and `ANALYTICS` with `PRIVATE` data visibility (ranking data is unique per account)