### PR TITLE
Add Contractors Cloud as a data source

### DIFF
--- a/organizations/contractors_cloud.json
+++ b/organizations/contractors_cloud.json
@@ -1,0 +1,7 @@
+{
+  "id": "CONTRACTORS_CLOUD",
+  "name": "Contractors Cloud",
+  "iconUrl":
+    "https://windsor.ai/wp-content/uploads/2026/05/contractors_cloud.png",
+  "orgUrl": "https://contractorscloud.com/"
+}

--- a/sources/contractors_cloud.json
+++ b/sources/contractors_cloud.json
@@ -1,0 +1,10 @@
+{
+  "id": "CONTRACTORS_CLOUD",
+  "name": "Contractors Cloud",
+  "categories": ["CRM", "SALES"],
+  "organization": "CONTRACTORS_CLOUD",
+  "iconUrl":
+    "https://windsor.ai/wp-content/uploads/2026/05/contractors_cloud.png",
+  "sourceUrl": "https://contractorscloud.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary
- Add new source `CONTRACTORS_CLOUD` (Contractors Cloud — contractor CRM/management platform) under categories CRM, SALES
- Add corresponding organization `CONTRACTORS_CLOUD`

## Test plan
- [x] JSON files validate
- [x] `id` matches filename convention
- [x] References valid existing categories (CRM, SALES)

🤖 Generated with [Claude Code](https://claude.com/claude-code)