### PR TITLE
Add Microsoft Clarity as a data source

### DIFF
--- a/sources/microsoft_clarity.json
+++ b/sources/microsoft_clarity.json
@@ -1,0 +1,10 @@
+{
+  "id": "MICROSOFT_CLARITY",
+  "name": "Microsoft Clarity",
+  "categories": ["ANALYTICS"],
+  "organization": "MICROSOFT",
+  "iconUrl":
+    "https://windsor.ai/wp-content/uploads/2026/05/microsoft-clarity.png",
+  "sourceUrl": "https://clarity.microsoft.com/",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary
- Add new source `MICROSOFT_CLARITY` (Microsoft Clarity — user behavior analytics: heatmaps, session recordings) under category ANALYTICS
- Reuses the existing `MICROSOFT` organization

## Test plan
- [x] JSON file validates
- [x] `id` matches filename convention
- [x] References valid existing category (ANALYTICS) and organization (MICROSOFT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)