### PR TITLE
Add Upcroft data source

### DIFF
--- a/organizations/upcroft.json
+++ b/organizations/upcroft.json
@@ -1,0 +1,6 @@
+{
+  "id": "UPCROFT",
+  "name": "Upcroft",
+  "iconUrl": "https://upcroft.ai/upcroft-data-studio-icon.png",
+  "orgUrl": "https://upcroft.ai/"
+}

--- a/sources/upcroft.json
+++ b/sources/upcroft.json
@@ -1,0 +1,9 @@
+{
+  "id": "UPCROFT",
+  "name": "Upcroft Data Warehouse",
+  "categories": ["ANALYTICS", "CUSTOMER_SUPPORT", "DATABASE"],
+  "organization": "UPCROFT",
+  "iconUrl": "https://upcroft.ai/upcroft-data-studio-icon.png",
+  "sourceUrl": "https://upcroft.ai/data-studio",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
## Summary

- add Upcroft as an organization
- add Upcroft Data Warehouse as a private data source
- categorize the source under Analytics, Customer Support, and Database

The source and icon metadata are hosted at https://upcroft.ai/data-studio.