### PR TITLE
Add Masha organization and source

### DIFF
--- a/organizations/masha.json
+++ b/organizations/masha.json
@@ -1,0 +1,6 @@
+{
+  "id": "MASHA",
+  "name": "Masha",
+  "iconUrl": "https://developers.masha.mx/looker/icon.png",
+  "orgUrl": "https://masha.mx"
+}

--- a/sources/masha.json
+++ b/sources/masha.json
@@ -1,0 +1,9 @@
+{
+  "id": "MASHA",
+  "name": "Masha",
+  "categories": ["ADVERTISING"],
+  "organization": "MASHA",
+  "iconUrl": "https://developers.masha.mx/looker/icon.png",
+  "sourceUrl": "https://masha.mx",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Adds `MASHA` as an organization and as a data source.

Masha is an advertising campaign management platform. The source is the campaign delivery data an advertiser sees for their own account: campaign metadata, impressions, clicks, CTR, completion rate, spend and budget. It backs a Looker Studio community connector for Masha's Reporting API.

`dataVisibility` is `PRIVATE`: each customer's API key returns only that account's campaigns, so two users connecting to the source receive different data.

**sources/masha.json**
```json
{
  "id": "MASHA",
  "name": "Masha",
  "categories": ["ADVERTISING"],
  "organization": "MASHA",
  "iconUrl": "https://developers.masha.mx/looker/icon.png",
  "sourceUrl": "https://masha.mx",
  "dataVisibility": ["PRIVATE"]
}
```

**organizations/masha.json**
```json
{
  "id": "MASHA",
  "name": "Masha",
  "iconUrl": "https://developers.masha.mx/looker/icon.png",
  "orgUrl": "https://masha.mx"
}
```

Both files were formatted with `npm run prettier`, and `scripts/check_filenames.sh` reports nothing for either. The icon is a static PNG on a domain we control and returns 200.
