### PR TITLE
Add Rank OS organization and reporting source

### DIFF
--- a/organizations/rank_os.json
+++ b/organizations/rank_os.json
@@ -1,0 +1,6 @@
+{
+  "id": "RANK_OS",
+  "name": "Rank OS",
+  "iconUrl": "https://rank-os-api-staging.up.railway.app/looker-connector-logo.png",
+  "orgUrl": "https://github.com/Team-Win-and-Make-Monney/rankos"
+}

--- a/organizations/rank_os.json
+++ b/organizations/rank_os.json
@@ -1,6 +1,6 @@
 {
   "id": "RANK_OS",
   "name": "Rank OS",
-  "iconUrl": "https://rank-os-api-staging.up.railway.app/looker-connector-logo.png",
-  "orgUrl": "https://github.com/Team-Win-and-Make-Monney/rankos"
+  "orgUrl": "https://github.com/Team-Win-and-Make-Monney/rankos",
+  "iconUrl": "https://rank-os-api-staging.up.railway.app/looker-connector-logo.png"
 }

--- a/sources/rank_os.json
+++ b/sources/rank_os.json
@@ -1,0 +1,9 @@
+{
+  "id": "RANK_OS",
+  "name": "Rank OS",
+  "categories": ["ANALYTICS", "SEO", "MARKETING"],
+  "organization": "RANK_OS",
+  "iconUrl": "https://rank-os-api-staging.up.railway.app/looker-connector-logo.png",
+  "sourceUrl": "https://rank-os-api-staging.up.railway.app/looker-connector.html",
+  "dataVisibility": ["PRIVATE"]
+}


### PR DESCRIPTION
Adds a Rank OS organization and private reporting source so a Community Connector manifest can set `sources: ["RANK_OS"]`.

This describes Rank OS project reporting data (rank tracker, website audit, backlinks, and leftover crawl / first-party Search Console inventory). It is not a licensed third-party keyword or SERP index.

Icon and source URLs currently point at the Rank OS staging origin. They can be updated if a first-party domain is attached later.